### PR TITLE
Fix description of stretchable lengths

### DIFF
--- a/eledmac.dtx
+++ b/eledmac.dtx
@@ -1229,7 +1229,7 @@
 % \changes{v1.0}{2012/09/15}{New generic commands to customize footnote display.}
 % Since version 1.0, some commands can be used to change the display of the footnotes. All can have an optional argument \oarg{s}, which is the letter of the series --- or a list of letters separated by comma --- depending on which option is applied.
 %
-% When a length, noted \meta{l}, is used, it can be stretchable: \verb|a minus b minus c|. The final length |m| is calculated by \LaTeX{} to have: $b-a \leq m \leq b+c$. If you use relative unity\footnote{Like \verb|em| which is the width of a M.}, it will be relative to fontsize of the footnote. 
+% When a length, noted \meta{l}, is used, it can be stretchable: \verb|a plus b minus c|. The final length |m| is calculated by \LaTeX{} to have: $a-c \leq m \leq a+b$. If you use relative unity\footnote{Like \verb|em| which is the width of a M.}, it will be relative to fontsize of the footnote. 
 %
 % \subsubsection{Control line number printing}
 % \DescribeMacro{\numberonlyfirstinline}


### PR DESCRIPTION
This previously seemed wrong both in the syntax (two `minus`es rather than one `plus` and one `minus`) and in the mathematical inequality, which I've corrected to match my formulation of the syntax; but both could be done differently.
