### PR TITLE
reledmac-doc on sidenotes fixed

### DIFF
--- a/reledmac.dtx
+++ b/reledmac.dtx
@@ -2507,9 +2507,8 @@
 % follows that for a \protect\cs{ledleftnote} or a \protect\cs{ledrightnote} depending
 % on the margin it is put in.
 %
-%    If two, say, \protect\cs{ledleftnote}, commands are called in the same line the
-% second \meta{text} will obliterate the first. There is no problem though with
-% having both a left and a right sidenote on the same line. 
+%    If two note commands for the same side are called in the same line, they will
+% be appended and separated by a comma.
 % \subsection{Setting}
 % \subsubsection{Width}
 % \DescribeMacro{\ledlsnotewidth}


### PR DESCRIPTION
Notes of the same line do not overwrite each other, they are appended.

MWE:
```
\listfiles

\documentclass{report}
\usepackage[utf8]{inputenc}
\usepackage[english]{babel}
\usepackage{reledmac}

\begin{document}
\beginnumbering
\pstart
This is\ledsidenote{Note 1} a line of text\ledrightnote{Note 2} with sidenotes.
\pend
\endnumbering
\end{document}
```