### PR TITLE
Partial fix for #392

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 *.synctex
 README
 reledmac/
+document*.tex

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 README
 reledmac/
 document*.tex
+reledmac.tex

--- a/reledmac.dtx
+++ b/reledmac.dtx
@@ -10599,6 +10599,7 @@
 % 
 % \changes{v1.4.0}{2012/11/16}{Direction of footnotes with polyglossia.}
 % \changes{v1.21.0}{2015/04/13}{\protect\cs{ledsetnormalparstuff} is deprecated and becomes \protect\cs{ledsetnormalparstuffX} and \protect\cs{Xledsetnormalparstuff}.}
+% \changes{}{2015/09/01}{Replaced \protect\cs{noindent} with \protect\cs{parinent}\protect\texttt{=0pt}.}
 %    \begin{macrocode} 
 \newcommand*{\ledsetnormalparstuff@common}{%
   \ifluatex%
@@ -10611,12 +10612,12 @@
 
 \newcommand*{\Xledsetnormalparstuff}[1]{%
   \ledsetnormalparstuff@common%
-  \nottoggle{Xparindent@#1}{\noindent}{}%\noindent and and not \parindent=0pt to avoid to break the (bad) change made when moving from ledmac to eledmac 
+  \nottoggle{Xparindent@#1}{\parindent=\z@}{}%
 }%
 
 \newcommand*{\ledsetnormalparstuffX}[1]{%
   \ledsetnormalparstuff@common%
-  \nottoggle{parindentX@#1}{\noindent}{}%\noindent and and not \parindent=0pt to avoid to break the (bad) change made when moving from ledmac to eledmac 
+  \nottoggle{parindentX@#1}{\parindent=\z@}{}%
 }%
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
Hi :-)

This commit provides a fix for the singe col footnotes regarding the correct behavior of the par indent setting, but unfortunately I could’t figure out how to fix this for two or three col notes … sorry!

Furthermore there was a comment in the `dtx` file saying that you used `\noindent` instead of `\parindent=0pt`, to prevent breaking a bad change, but that actually caused the wrong behavior so I removed it but to be honest I didn’t understand your comet, so maybe my fix doesn’T help at all …

Tobi