### PR TITLE
Issue402

### DIFF
--- a/reledmac.dtx
+++ b/reledmac.dtx
@@ -1217,6 +1217,8 @@
 % \usepackage[parapparatus]{eledmac}
 % \end{verbatim}
 %
+% Note that you \emph{can not} use paragraphs (e.g. blank lines or \cs{par}) inside of notes, when they are set to \texttt{paragraph} arrangement!
+%
 % \subsubsection{Change lemma and line number}
 % \DescribeMacro{\lemma}
 % \changes{v1.0.0}{2012/09/15}{\protect\cs{lemma} can contain commands.}
@@ -1541,6 +1543,8 @@
 % the break very strongly: {\tt \bslash penalty=-9999} will do
 % the trick. \reff{nobreak} explains why this restriction
 % is necessary.}
+%
+% Note that you \emph{can not} use paragraphs (e.g. blank lines or \cs{par}) inside of notes, when they are set to \texttt{paragraph} arrangement!
 %
 % The notes arrangement must be called after having defined the document geometry setting. If you must change geometry setting inside your document, do not forget to call again note arrangement.
 % 

--- a/reledmac.dtx
+++ b/reledmac.dtx
@@ -11396,7 +11396,7 @@
 % Note the double \# in command: it is because a command is called inside another command.
 %    \begin{macrocode}
 
-      \global\expandafter\newcommand\csname footnote#1\endcsname[1]{%
+      \global\notbool{parapparatus@}{\expandafter\newcommand\expandafter *}{\expandafter\newcommand}\csname footnote#1\endcsname[1]{%
           \begingroup%
               \prepare@prenotesX{#1}%
               \newcommand{\content}{##1}%


### PR DESCRIPTION
This should solve #402 in cases when `parapparatus` option is not active. There’s still nor error with this option activated for familiar footnotes. There must be a missing `*` somewhere in the code but I couldn’t find the place.

Since in case of `parapparatus` the error in critical footnotes is linked to `\vAfootnote` instead of `\Afootnote` I tried to find the equivalent of it for familiar nots, but didn’t find it. For further testing you may use this code

```
\documentclass{article}

\usepackage[
   parapparatus,
]{reledmac}

\Xarrangement[A]{paragraph}
\arrangementX[A]{paragraph}

\newcommand{\sometext}{%
   Nam dui ligula, fringilla a, euismod sodales, sollicitudin vel, wisi. Morbi
   auctor lorem non justo. Nam lacus libero, pretium at, lobortis vitae, ultricies
   et, tellus.
}

\begin{document}
% with 'parapparatus' an errormessage is missing
Test\footnoteA{Text

Text}
Test\footnoteA{\textbf{Normal A}: \sometext}
Test\footnoteA{\textbf{Normal A}: \sometext}

% works as expected
\beginnumbering
   \pstart
   \edtext{Test}{\Afootnote{\textbf{Critical A}: \sometext
   
    \sometext}}
   \edtext{Test}{\Afootnote{\textbf{Critical A}: \sometext}}
   \edtext{Test}{\Afootnote{\textbf{Critical A}: \sometext}}
   \pend
\endnumbering
\end{document}
```

But using `parapparatus` is a deliberate decision of the use and so he should be aware of problems with pars in paragraphed notes. I added a note on that in the manual, though …