### PR TITLE
Options for reledpar

### DIFF
--- a/reledpar.dtx
+++ b/reledpar.dtx
@@ -1149,7 +1149,7 @@
 \DeclareOptionX{parledgroup}{\parledgrouptrue}
 %    \end{macrocode}
 % \begin{macro}{\ifwidthliketwocolumns}
-% The \protect\cs{widthliketwocolumns} option can be called either on \macpackage or \parpackage.
+% The \verb|widthliketwocolumns| option can be called either on \macpackage or \parpackage.
 % \changes{v1.9.0}{2014/09/16}{Added widthliketwocolumns option}
 %    \begin{macrocode}
 \DeclareOptionX{widthliketwocolumns}{\widthliketwocolumnstrue}%

--- a/reledpar.dtx
+++ b/reledpar.dtx
@@ -338,6 +338,37 @@
 % Names of the package related to parallel typesetting have moved in parallel of names of the package related to critical edition.
 % 
 % Please read \macpackage's handbook in order to understand this evolution.
+%
+% \section{Options}
+% The package can be loaded with a number of global options which are listed
+% here.
+% \subsection{Synchronization's options}
+% \begin{description}
+%    \item [shiftedpstarts] prevents white space between paragraphs on facing pages,
+%       the white space necessary to sync pages is collected at the bottom of
+%       the page instead.
+%    \item [advancedshiftedpstarts] does the same as \verb|shiftedpstarts|, but
+%       the pstart shift are not counted to determine when cutting the page. That
+%       could help to avoid page with blank lines at the bottom. Not compatible
+%       with \verb|nomaxlines|!
+%    \item [nomaxlines] allows facing pages to have different numbers of lines.
+%    \item [nosyncpstarts] disables syncing on facing pages. In that case the pages
+%       are filled as two streams normal.
+% \end{description}
+% \subsection{Other options}
+% \begin{description}
+%    \item [parledgroup]  allows the use of \verb|ledgroup| environment with \parpackage.*
+%    \item [widthliketwocolumns] set the width of the text printed in a single
+%       column to be the same as the width of the text printed in two parallel
+%       columns with \parpackage. This is useful when alternating between normal and
+%       parallel typesetting.*
+%    \item [sameparallelpagenumber] sets page numbers on facing pages to the same value.
+%    \item [prevpgnotnumbered] enables that the page before facing pages (the one
+%       automatically inserted to start parallel pages on a left page) is not
+%       counted. This applies only if the page is empty.
+% \end{description}
+% \textit{* This option can either be used on \macpackage or \parpackage.}
+%
 % \section{General}\label{howto}
 %
 % A file may mix \emph{numbered} and \emph{unnumbered} text.

--- a/reledpar.dtx
+++ b/reledpar.dtx
@@ -529,9 +529,9 @@
 % and right pages, respectively. By default, these are set to the normal
 % textwidth for the document, but can be changed within the environment if
 % necessary.
-% \subsubsection{Way of synchronizing\footnote{There is a French version of this article on \url{http://geekographie.maieul.net/185}.} 
-%Synchronization of left and right texts in parallel processing
-%requires some `numbered' auxiliary files to be written (namely \verb+.1+,
+% \subsubsection[Way of synchronizing]{Way of synchronizing\footnote{There is a French version of this article on \url{http://geekographie.maieul.net/185}.}} 
+% Synchronization of left and right texts in parallel processing
+% requires some `numbered' auxiliary files to be written (namely \verb+.1+,
 %\verb+.1R+, \verb+.2+, \verb+.2R+, and so forth), the content of which may change as long
 %as synchronization is not complete. This usually requires LaTeX to be
 %run several times. Therefore, it is advised to use in conjunction
@@ -601,7 +601,7 @@
 %shorter corresponding one also runs across pages, even if this may
 %result in some blank vertical space being left on the first page.
 %				\end{itemize}
-%		\end{itemize}
+%		\end{enumerate}
 %		\item As regards the number of lines per page, including blank ones, the
 %\option{nomaxlines} setting disregards the rule that forces two facing pages
 %to have the same numbers of lines. So it allows to have more text on
@@ -609,7 +609,7 @@
 %corresponding chunks may always start on the same facing pages,
 %provided that \option{shiftedpstarts} or \option{advancedshiftedpstarts} settings
 %shall be not activated.
-%\end{itemize}
+%\end{enumerate}
 %
 %Lastly, one may disregard all of the synchronization rules and content
 %himself with parallel texts typesetting. To achieve this, please use
@@ -1301,7 +1301,6 @@
   \reledpar@error{Fail to patch \string\@outputpage\space command.}{\@ehc}%
 }%
 %    \end{macrocode}
-% \end{macro}
 % \end{macro}
 % \begin{macro}{\led@warn@ChangeSyncOption}
 %    \begin{macrocode}


### PR DESCRIPTION
I added the option list and fixed some errors in `reledpar.dtx` to make it compilable.

Note: I copied your explanation of `advancedshiftedpstarts` but actually didn’t understand the difference between `shiftedpstarts` and `advancedshiftedpstarts` …