### PR TITLE
Mark's English corrections

### DIFF
--- a/examples/4-reledpar_column_mix_with_not_column-continuous-numbering.tex
+++ b/examples/4-reledpar_column_mix_with_not_column-continuous-numbering.tex
@@ -18,9 +18,9 @@
 \begin{document}
 
 \begin{english}
-\title{Mixing columns with not column, using continuous numbering}
+\title{Mixing multiple columns with a single column, using continuous numbering}
 \begin{abstract}
-In this example, we use the \verb+widthliketwocolumns+ and \\ \verb+continuousnumberingwithcolumns+ and \verb+\pausenumbering+ to alternate parallel typesetting in columns and normal typesetting, getting continuous line numbering between them.
+In this example, we use the \verb+widthliketwocolumns+ and \\ \verb+continuousnumberingwithcolumns+ and \verb+\pausenumbering+ to alternate parallel typesetting in columns and typesetting in a single column, getting continuous line numbering between them.
 \end{abstract}
 \end{english}
 \begin{pairs}  

--- a/examples/4-reledpar_column_mix_with_not_column.tex
+++ b/examples/4-reledpar_column_mix_with_not_column.tex
@@ -18,10 +18,10 @@
 \begin{document}
 
 \begin{english}
-\title{Mixing columns with not column}
+\title{Mixing multiple columns with single column}
 \maketitle
 \begin{abstract}
-In this example, we use the \verb+widthliketwocolumns+ option and the \verb+\Xnoteswidthliketwocolumns+ and \verb+\noteswidthliketwocolumnsX+ to alternate parallel typesetting in columns and normal typesetting.
+In this example, we use the \verb+widthliketwocolumns+ option and the \verb+\Xnoteswidthliketwocolumns+ and \verb+\noteswidthliketwocolumnsX+ to alternate parallel typesetting in multiple columns and single column typesetting.
 \end{abstract}
 \end{english}
 

--- a/reledmac.dtx
+++ b/reledmac.dtx
@@ -382,15 +382,15 @@
 % \changes{v2.8.0}{2016/01/15}{\protect\macpackage cross-referencing can take advantage of \protect\package{xr} package.}
 % \changes{v2.8.0}{2016/01/15}{No indentation for paragraphed notes in ledgroup. Can be changed with \protect\cs{Xparindent} and \protect\cs{parindentX}.}
 % \changes{v2.8.0}{2016/01/15}{More \protect\cs{edgls…} commands.}
-% \changes{v2.8.1}{2016/02/22}{Warning for undefined labels are really parsable by latexmk}
+% \changes{v2.8.1}{2016/02/22}{Warnings for undefined labels are really parsable by latexmk}
 % \changes{v2.8.2}{2016/02/27}{Fix bug with \protect\cs{AtEveryPstart} added in version 2.0.0.}
-% \changes{v2.8.2}{2016/02/27}{Fix bug with vertical space after between sectioning command as optional argument of a \protect\cs{pstart} and \protect\cs{pstart} content}
-% \changes{v2.8.2}{2016/02/27}{Fix bug concerning indent in a paragraph immediatly following  a sectioning command (bug NOT fixed on reledpar)}
-% \changes{v2.9.0}{2016/03/23}{Allow to make continuing line numbering between normal text and parallel text, using \protect\cs{pausenumbering} and \protect\cs{resumenumbering} and the \protect\option{continuousnumberingwithcolumns} option.}
+% \changes{v2.8.2}{2016/02/27}{Fix bug with vertical space after the between-sectioning command as optional argument of a \protect\cs{pstart} and \protect\cs{pstart} content}
+% \changes{v2.8.2}{2016/02/27}{Fix bug concerning indent in a paragraph immediately following a sectioning command (bug NOT fixed on reledpar)}
+% \changes{v2.9.0}{2016/03/23}{Allow continuing line numbering between normal text and parallel text, using \protect\cs{pausenumbering} and \protect\cs{resumenumbering} and the \protect\option{continuousnumberingwithcolumns} option.}
 % \changes{v2.9.0}{2016/03/23}{Fix bug when using \protect\cs{linenum}\protect\arg{page} and \protect\cs{pausenumbering}\protect\ldots\protect\cs{resumenumbering}.}
 % \changes{v2.9.0}{2016/03/23}{Write correct metadata in numbered files when using \protect\cs{pausenumbering}\protect\ldots\protect\cs{resumenumbering}.}
-% \changes{v2.9.0}{2016/03/23}{Fix bug with three and two columns footnote setting (added in v.2.4.0).}
-% \changes{v2.9.0}{2016/03/23}{Fix spurious space inside three columns familiar footnote.}
+% \changes{v2.9.0}{2016/03/23}{Fix bug with three- and two-column footnote setting (added in v.2.4.0).}
+% \changes{v2.9.0}{2016/03/23}{Fix spurious space inside three-column familiar footnote.}
 % \title{\Macpackage \\
 %      Typeset scholarly editions with \LaTeX\thanks{This file (\dtxfilename)
 % has version number \fileversion, last revised \filedate.}}
@@ -639,8 +639,8 @@
 % problems with a line or two misnumbered at the top of a page, try
 % running \LaTeX\ once or twice more.
 % 
-% However, the best way to be sure to have made the good number of runs 
-% is to use some \LaTeX's run scripts like \emph{latexmk}.
+% However, the best way to be sure that one has made the right number of runs 
+% is to use some of \LaTeX's run scripts like \emph{latexmk}.
 %
 % A file may mix \emph{numbered} and \emph{unnumbered} text.
 %
@@ -7341,8 +7341,8 @@
   \normal@pars%
   \ifstrempty{#1}{\at@every@pend}{\noindent#1}%
 %    \end{macrocode}
-% Restore  standard nobreak setting and autopar setting. 
-% Normally, \cs{if@nobreak} is equal to true only immediatly after a sectioning command (read latex.ltx file). As a \cs{pstart}…\cs{pend} structure can't contain any sectioning command, we set \cs{if@nobreak} to false. 
+% Restore standard nobreak setting and autopar setting. 
+% Normally, \cs{if@nobreak} is equal to true only immediately after a sectioning command (read latex.ltx file). As a \cs{pstart}…\cs{pend} structure can't contain any sectioning command, we set \cs{if@nobreak} to false. 
 %    \begin{macrocode}
   \@nobreakfalse%
   \ifautopar%

--- a/reledpar.dtx
+++ b/reledpar.dtx
@@ -266,8 +266,8 @@
 % \changes{v2.6.2}{2015/11/29}{Fix bug (added in v2.6.0) with footnote numbering in parallel typesetting while using \protect\package{polyglossia} with specific numbering systems (like Greek).}
 % \changes{v2.6.3}{2015/12/13}{Fix spurious dot when using \protect\cs{linenummargin} on right side (introduced in v2.5.0).}
 % \changes{v2.7.0}{2016/01/15}{\protect\macpackage cross-referencing can take advantage of \protect\package{xr} package.}
-% \changes{v2.7.1}{2016/03/06}{Fix bug added in \protect\reledmac~2.8.2, when typesetting parallel text just after a sectionning command}
-% \changes{v2.8.0}{2016/03/23}{{Allow to make continuing line numbering between normal text and parallel text, using \protect\cs{pausenumbering} and \protect\cs{resumenumbering} and the \protect\option{continuousnumberingwithcolumns} option.}}
+% \changes{v2.7.1}{2016/03/06}{Fix bug added in \protect\reledmac~2.8.2, when typesetting parallel text just after a sectioning command}
+% \changes{v2.8.0}{2016/03/23}{{Allow continuing line numbering between normal text and parallel text, using \protect\cs{pausenumbering} and \protect\cs{resumenumbering} and the \protect\option{continuousnumberingwithcolumns} options.}}
 % \changes{v2.8.0}{2016/03/23}{Fix bug when the right line number style is not the same to the left line number style}
 % \changes{v2.8.0}{2016/03/23}{Add \protect\cs{linenumberLevenifblanktrue} and \protect\cs{linenumberRevenifblank} commands}
 % ^^A PW added following as the definitions are at some unknown elsewhere
@@ -546,7 +546,7 @@
 % In most cases, you should use \protect\cs{widthliketwocolumns} in combination with \protect\cs{Xnoteswidthliketwocolumns} and \protect\cs{notesXwidthliketwocolumns} to align the critical/familiar footnotes with the two colums. 
 % See \macpackage's handbook for more details.
 %
-% If you want to have  continuous line numbers between columns and not column, use the \option{continuousnumberingwithcolumns} option when loading \macpackage or \parpackage.
+% If you want to have continuous line numbers between multiple columns and single columns, use the \option{continuousnumberingwithcolumns} option when loading \macpackage or \parpackage.
 % You will need to use \cs{pausenumbering}\ldots\cs{resumenumbering} instead of \cs{endnumbering}\ldots{endnumbering} (see \reff{reledmac-pause}).
 %
 %
@@ -938,8 +938,8 @@
 %
 % \DescribeMacro{\linenumberLevenifblanktrue}
 % \DescribeMacro{\linenumberRevenifblanktrue}
-% By default, when a blank line is printed on one side for the need of synchronism with the other side, no line number is printed.
-% However, you can decide to print them also for blank lines.
+% By default, when a blank line is printed on one side, in order to synchronize with the other side, no line number is printed.
+% However, you can decide to print them for blank lines, also.
 % Use \cs{linenumberLevenifblanktrue} to enable it on the left side, and \cs{linenumberRevenifblanktrue} to enable it on right side.
 %
 % \subsection{Chunks}
@@ -1706,7 +1706,7 @@
 % \end{macro}
 %
 % \begin{macro}{\set@continuousnumberingforR}
-% \cs{set@continuousnumberingforR} set the right line numbers at a \cs{beginnumberingR} or a \cs{resumenumberingR} in order to have continuous numbering with not parallel text. 
+% \cs{set@continuousnumberingforR} set the right line numbers at a \cs{beginnumberingR} or a \cs{resumenumberingR} in order to have continuous numbering with not parallel text (do you mean `single column text'?). 
 %    \begin{macrocode}
 \newcommand{\set@continuousnumberingforR}{%
   \ifcontinuousnumberingwithcolumns%
@@ -1934,7 +1934,7 @@
 % \subsection{Print marginal line number}
 % \begin{macro}{\iflinenumberLevenifblank}
 % \begin{macro}{\iflinenumberRevenifblank}
-% \cs{iflinenumberLevenifblank} and \cs{iflinenumberRevenifblank} can be switchen to TRUE if we want to print the line number even if the line is blank.
+% \cs{iflinenumberLevenifblank} and \cs{iflinenumberRevenifblank} can be switched to TRUE if we want to print the line number, even if the line is blank.
 %    \begin{macrocode}
 \newif\iflinenumberLevenifblank
 \newif\iflinenumberRevenifblank
@@ -6370,8 +6370,8 @@
 % \begin{macro}{\par@patch@pagenumbering}
 % \cs{par@patch@thepage} patches \cs{thepage} in order to use the value of \verb+par@page+ counter and not the value of \verb+par@page+.  
 % It must be called after any redefinition of \cs{thepage}. 
-% That why we insert it at the end of the \LaTeX\ macro \cs{pagenumbering}, which is called by some \cs{xxxmatter} commands. 
-% In the case of \ltxclass{memoir} class using, we insert it at the end of  \cs{@mempnum}.
+% That is why we insert it at the end of the \LaTeX\ macro \cs{pagenumbering}, which is called by some \cs{xxxmatter} commands. 
+% In cases when we are using the \ltxclass{memoir} class, we insert it at the end of  \cs{@mempnum}.
 % When using \cs{pagenumbering}, we also need to restart \verb+par@page+ counter. Consequently, we have wrapped \cs{par@patch@thepage} and counter restart in \cs{par@patch@pagenumbering}
 % We also call \cs{par@patch@thepage} it at the beginning of the document.
 %    \begin{macrocode}


### PR DESCRIPTION
- Misc. corrections for minor English typographical errors
- Change "not column" or "no column" to "single column(s)"