### PR TITLE
Typos fixed

### DIFF
--- a/reledpar.dtx
+++ b/reledpar.dtx
@@ -564,8 +564,8 @@
 % \end{itemize}
 % You can redefine \protect\cs{beforecolumnseparator} and \protect\cs{aftercolumnseparator} length to define spaces before or after the column separator, instead of letting \parpackage calculate them automatically. 
 % \begin{verbatim}
-% \setlength{\beforecolumseparator}{length}
-% \setlength{\aftercolumseparator}{length}
+% \setlength{\beforecolumnseparator}{length}
+% \setlength{\aftercolumnseparator}{length}
 % \end{verbatim}
 % If you want to revert to the previous behavior, just set with a negative value. 
 % \subsubsection{Mixing two columns and one column texts}


### PR DESCRIPTION
\beforecolumnseparator, \aftercolumnseparator