### PR TITLE
Draft for documentation of \swnoexpands

### DIFF
--- a/reledmac.dtx
+++ b/reledmac.dtx
@@ -1753,6 +1753,23 @@
 %}
 % \end{verbatim}
 %
+% \DescribeMacro{\swnoexpands}Macros that manipulate font features inside \protect\cs{sameword} may cause problems during compilation. Custom commands inside \protect\cs{sameword} may therefore result in errors saying that `Use of \\sameword doesn't match its definition.` To solve this, include your custom commands in the \protect\cs{swnoexpands} list. To not include any content of a macro during comparison, identify the command with \protect\cs{@gobble}, to include the. For example:
+% \begin{verbatim}
+%\makeatletter
+%\appto{\swnoexpands}{%
+%  \let\somemacro\@gobble%
+%}
+%\makeatother
+% \end{verbatim}
+% This will drop the content of \protect\cs{somemacro} during comparison. To include the content of the first argument of a custom command in sameword comparison, use the \protect\cs{@firstofone} command. For example this is how \protect\cs{emph} is handled:
+% \begin{verbatim}
+%\makeatletter
+% \appto{\swnoexpands}{%
+%  \let\emph\@firstofone%
+%}
+%\makeatother
+% \end{verbatim}
+%
 % \subsubsection{Automatic sameword annotation}
 % All potentially ambiguous apparatus entries must be annotated manually. That
 % annotation process is laborious and includes a risk of errors.


### PR DESCRIPTION
This may be inaccurate or unclear, but it's something to work with. 
To be honest I couldn't get it to produce any errors (even with custom declared command using \emph{}). But I may just be daft.