### PR TITLE
Rendre les exemples compatibles avec PDFLaTeX / XeLaTeX / LuaLaTeX

### DIFF
--- a/examples/1-criticalendotes.tex
+++ b/examples/1-criticalendotes.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/1-criticalendotes.tex
+++ b/examples/1-criticalendotes.tex
@@ -1,8 +1,9 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 \usepackage[series={A,B},nocritical,noeledsec,nofamiliar,noledgroup]{reledmac}
 \Xendparagraph[B]

--- a/examples/1-criticalnotes.tex
+++ b/examples/1-criticalnotes.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/1-criticalnotes.tex
+++ b/examples/1-criticalnotes.tex
@@ -1,8 +1,9 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 \usepackage[series={A,B,C,D},noend,noeledsec,nofamiliar,noledgroup]{reledmac}
 \Xarrangement[B]{twocol}

--- a/examples/1-sidenotes.tex
+++ b/examples/1-sidenotes.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/1-sidenotes.tex
+++ b/examples/1-sidenotes.tex
@@ -1,13 +1,14 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 \usepackage[series={},nocritical,noend,noeledsec,nofamiliar,noledgroup]{reledmac}
 \sidenotemargin{outer}
-\renewcommand{\ledlsnotefontsetup}{\small\it}% left
-\renewcommand{\ledrsnotefontsetup}{\small\it}% right
+\renewcommand{\ledlsnotefontsetup}{\small\itshape}% left
+\renewcommand{\ledrsnotefontsetup}{\small\itshape}% right
 \leftnoteupfalse
 \rightnoteupfalse
 \setsidenotesep{ $|$ }
@@ -20,7 +21,7 @@
 \maketitle
 \begin{abstract}
 This file provides examples of side notes with reledmac. 
-We use :
+We use:
 \begin{itemize}
   \item \verb+\ledleftnote+ (left notes); 
   \item \verb+\ledrightnote+ (right notes); 

--- a/examples/1-tabular.tex
+++ b/examples/1-tabular.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/1-tabular.tex
+++ b/examples/1-tabular.tex
@@ -1,9 +1,9 @@
-\documentclass{article}
-\usepackage{fontspec}
-\usepackage{libertineotf}
-\usepackage{polyglossia}
-\setmainlanguage{italian}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=italian]{babel}
+\babeltags{english = english}
 
 \usepackage[series={A,B},noend,noeledsec,noledgroup]{reledmac}
 \firstlinenum{1}

--- a/examples/1-verses-doublenumbering.tex
+++ b/examples/1-verses-doublenumbering.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/1-verses-doublenumbering.tex
+++ b/examples/1-verses-doublenumbering.tex
@@ -1,8 +1,9 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 \usepackage[series={A,B},noend,noeledsec,noledgroup]{reledmac}
 \sethangingsymbol{[\,}

--- a/examples/1-verses.tex
+++ b/examples/1-verses.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/1-verses.tex
+++ b/examples/1-verses.tex
@@ -1,8 +1,9 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 \usepackage[series={A,B},noend,noeledsec,noledgroup]{reledmac}
 \sethangingsymbol{[\,}

--- a/examples/2-cross_referencing.tex
+++ b/examples/2-cross_referencing.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-cross_referencing.tex
+++ b/examples/2-cross_referencing.tex
@@ -1,10 +1,11 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
+
 \usepackage[series={A},noend,noeledsec,nofamiliar,noledgroup]{reledmac}
-\usepackage{hyperref}
 
 \setapprefprefixsingle{l.~}
 \setSErefprefixsingle{l.~}

--- a/examples/2-footnote_spacing.tex
+++ b/examples/2-footnote_spacing.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-footnote_spacing.tex
+++ b/examples/2-footnote_spacing.tex
@@ -1,10 +1,10 @@
-\documentclass{article}
-\usepackage{fontspec}
-\usepackage{libertineotf}
-\usepackage{polyglossia}
-\setmainlanguage{latin}
-\setotherlanguage{english}
-\usepackage{SIunits}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
+\usepackage[detect-all]{siunitx}
 
 \usepackage[series={A,B,C},noend,noeledsec,noledgroup]{reledmac}
 
@@ -34,9 +34,9 @@
 \title{Setting spaces around footnote rules}
 \maketitle
 \begin{abstract}
-This file sets spaces around footnote rules, to have a uniform \unit{3}{\milli\meter} before and after. There are three levels of paragraphed notes. Before the first series of notes, we have \unit{0.5}{\centi\meter}.
+This file sets spaces around footnote rules, to have a uniform \SI{3}{\milli\meter} before and after. There are three levels of paragraphed notes. Before the first series of notes, we have \SI{0.5}{\centi\meter}.
 
-We use \verb+\Xbeforenotes+ and \verb+\Xafterrule+. There is, anyway, a subtlety: the footnote rule of reledmac is the standard \LaTeX footnote rule: \verb+\footnoterule+, which automatically decreases \unit{3}{pt} before and adds \unit{2.6}{pt} after. So we have to compensate, by defining to length:  \verb+before+ and \verb+\after+, which are passed to the respective commands. 
+We use \verb+\Xbeforenotes+ and \verb+\Xafterrule+. There is, anyway, a subtlety: the footnote rule of reledmac is the standard \LaTeX footnote rule: \verb+\footnoterule+, which automatically decreases \SI{3}{pt} before and adds \SI{2.6}{pt} after. So we have to compensate, by defining to length:  \verb+before+ and \verb+\after+, which are passed to the respective commands. 
 \end{abstract}
 \end{english}
 

--- a/examples/2-glossaries.tex
+++ b/examples/2-glossaries.tex
@@ -1,8 +1,11 @@
-\documentclass{article}
-\usepackage{polyglossia}
-\setotherlanguage{english}
-\setmainlanguage{italian}
-\usepackage{libertine}
+\documentclass{scrartcl}
+\usepackage{amsmath}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=italian]{babel}
+\babeltags{english = english}
+
 \usepackage[nocritical,noend,noeledsec,series={A},nofamiliar]{reledmac}
 
 \usepackage{glossaries}
@@ -11,7 +14,6 @@
 \newglossaryentry{monistero}{name={monistero},description={monastero}}  
 \newglossaryentry{magicien}{name={magicien},description={sorcier}}  
 
-%
 \begin{document}
 
 \begin{english}

--- a/examples/2-glossaries.tex
+++ b/examples/2-glossaries.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage{amsmath}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}

--- a/examples/2-indexing.tex
+++ b/examples/2-indexing.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-indexing.tex
+++ b/examples/2-indexing.tex
@@ -1,8 +1,9 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 \usepackage[nonewpage]{indextools}
 
 \usepackage[series={A},noend,noeledsec,nofamiliar,noledgroup]{reledmac}

--- a/examples/2-lemma_disambigution.tex
+++ b/examples/2-lemma_disambigution.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-lemma_disambigution.tex
+++ b/examples/2-lemma_disambigution.tex
@@ -1,9 +1,11 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
+
 \usepackage[series={A,B},nofamiliar,noend,noeledsec,noledgroup]{reledmac}
-\setmainlanguage{latin}
-\setotherlanguage{english}
 \begin{document}
 
 

--- a/examples/2-line_numbers_in_header.tex
+++ b/examples/2-line_numbers_in_header.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-line_numbers_in_header.tex
+++ b/examples/2-line_numbers_in_header.tex
@@ -1,9 +1,9 @@
-\documentclass[]{article}
-\usepackage{fontspec}
-\usepackage{libertineotf}
-\usepackage{polyglossia}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 % CONFIG FANCYHDR TO SHOW LEFT/RIGHT MARKS IN HEADERS
 \usepackage{fancyhdr}

--- a/examples/2-linespacing.tex
+++ b/examples/2-linespacing.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-linespacing.tex
+++ b/examples/2-linespacing.tex
@@ -1,9 +1,9 @@
-\documentclass[12pt]{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
-
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 \usepackage{setspace}
 \AtBeginDocument{\doublespacing}

--- a/examples/2-manuscript-apparatus.tex
+++ b/examples/2-manuscript-apparatus.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-manuscript-apparatus.tex
+++ b/examples/2-manuscript-apparatus.tex
@@ -1,8 +1,10 @@
-\documentclass{article}
-\usepackage{libertineotf}
-\usepackage{polyglossia}
-\setmainlanguage{english}
-\setotherlanguage{latin}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
+
 \usepackage[noend, nopenalties, nofamiliar, noeledsec, series={A,B}]{reledmac}
 \usepackage{reledpar}
 

--- a/examples/2-notes-width.tex
+++ b/examples/2-notes-width.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-notes-width.tex
+++ b/examples/2-notes-width.tex
@@ -1,10 +1,11 @@
-\documentclass[12pt]{article}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 \usepackage{lipsum}
-\usepackage{polyglossia}
-\usepackage{libertineotf}
-\usepackage[a4paper,textwidth=12cm]{geometry}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+
 \usepackage[noend,noeledsec,noledgroup,series={A,B,C,D}]{reledmac}
 \Xarrangement[A]{paragraph}
 \Xarrangement[B]{twocol}

--- a/examples/2-one_series_per_pstart.tex
+++ b/examples/2-one_series_per_pstart.tex
@@ -1,10 +1,12 @@
-\documentclass{article}
-\usepackage[series={A,B,C,D,E},noend,noeledsec,nofamiliar,noledgroup]{reledmac}
-\usepackage{lipsum,polyglossia}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english]{babel}
+\usepackage{lipsum}
 \SetLipsumParListEnd{\par}
-\setmainlanguage{english}
-\usepackage{libertine}
 
+\usepackage[series={A,B,C,D,E},noend,noeledsec,nofamiliar,noledgroup]{reledmac}
 
 \newcounter{mynotelevel}%A counter to dump the note level
 \renewcommand{\themynotelevel}{\Alph{mynotelevel}}% The counter is seen as a letter

--- a/examples/2-one_series_per_pstart.tex
+++ b/examples/2-one_series_per_pstart.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-performances.tex
+++ b/examples/2-performances.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-performances.tex
+++ b/examples/2-performances.tex
@@ -1,8 +1,9 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 \usepackage[series={},nocritical,noend,nofamiliar,noeledsec,noledgroup]{reledmac}
 

--- a/examples/2-reledmac-right-to-left.tex
+++ b/examples/2-reledmac-right-to-left.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-reledmac-right-to-left.tex
+++ b/examples/2-reledmac-right-to-left.tex
@@ -1,12 +1,24 @@
-\documentclass[12pt]{article}
-\usepackage{libertineotf}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
 \usepackage[noend,nofamiliar,noeledsec,series={A}]{reledmac}
-\usepackage{fontspec}
-\usepackage{polyglossia}
-\setmainlanguage{english}
-\setotherlanguage{hebrew}
 
-\newfontfamily{\hebrewfont}[Scale=0.9]{Ezra SIL}
+\usepackage{ifluatex}
+\ifluatex
+  \usepackage[main=english,bidi=basic]{babel}
+  \babelprovide[import=he]{hebrew}
+  \babelfont{rm}{Libertinus Serif}
+  \babelfont[hebrew]{rm}{Ezra SIL}
+  \newcommand{\texthebrew}[2][]{\foreignlanguage{hebrew}{#2}}
+  \newenvironment{hebrew}[2][]{\begin{otherlanguage}{hebrew}}{\end{otherlanguage}}
+  \usepackage{metalogo}
+\else
+  \usepackage{polyglossia}
+  \setmainlanguage{english}
+  \setotherlanguage{hebrew}
+  \newfontfamily{\hebrewfont}[Scale=0.9]{Ezra SIL}
+\fi
 
 \Xarrangement{paragraph}
 \Xbeforeinserting{\LTR}
@@ -30,9 +42,9 @@ In this file, we provide an example of an edition with right-to-left text and le
 
 \begin{itemize}
 	\item The `hebrew' environment allows us to write Hebrew right-to-left.
-	\item The \verb+\Xbeforeinserting{\LTR}+ makes the critical notes to be typeset left-to-right.
-	\item The \verb+\Xwraplemma{\RL}+ assures the lemmas, which are in Hebrew, be typeset right-to-left.
-	\item The \verb+\Xwrapcontent{\textenglish}+ assures the content of the note is marked as English text. 
+	\item \verb+\Xbeforeinserting{\LTR}+ makes the critical notes to be typeset left-to-right.
+	\item \verb+\Xwraplemma{\RL}+ assures the lemmas, which are in Hebrew, be typeset right-to-left.
+	\item \verb+\Xwrapcontent{\textenglish}+ assures the content of the note is marked as English text. 
 	\item As the `Ezra SIL' font transforms a `]' to a `[', we use a `[' as lemma separator, that will be typeset as `]' by `Ezra SIL'. So the need for \verb+\Xlemmaseparator+ is not directly linked to reledmac.
 \end{itemize}
 

--- a/examples/2-subdivision-number-in-header.tex
+++ b/examples/2-subdivision-number-in-header.tex
@@ -1,10 +1,11 @@
-\documentclass[twoside]{article}
-\usepackage{fontspec}
-\usepackage{libertineotf}
-\usepackage{polyglossia}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass[twoside]{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 \usepackage[series={},noend,nocritical,noeledsec,nofamiliar]{reledmac}
+
 % CONFIG FANCYHDR TO SHOW LEFT/RIGHT MARKS IN HEADERS
 \usepackage{fancyhdr}
 \pagestyle{fancy}
@@ -43,7 +44,7 @@
 \end{english}
 
 \begin{english}
-\section{Manuel subdivision number}
+\section{Manual subdivision number}
 
 \begin{abstract}
  In this example, the verse (sentence) number is typeset directly in the source code.

--- a/examples/2-subdivision-number-in-header.tex
+++ b/examples/2-subdivision-number-in-header.tex
@@ -1,4 +1,4 @@
-\documentclass[twoside]{scrartcl}
+\documentclass[twoside]{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-titles_in_line_numbering_with_notes.tex
+++ b/examples/2-titles_in_line_numbering_with_notes.tex
@@ -1,4 +1,4 @@
-\documentclass{scrbook}
+\documentclass{book}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/2-titles_in_line_numbering_with_notes.tex
+++ b/examples/2-titles_in_line_numbering_with_notes.tex
@@ -1,7 +1,9 @@
-\documentclass[twoside,12pt]{book}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{english}
+\documentclass{scrbook}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english]{babel}
+\babeltags{english = english}
 
 \usepackage[series={A},noend,nofamiliar,noledgroup]{reledmac}
 \linenumincrement{1}
@@ -20,6 +22,7 @@ We use the \verb+\reledxxx+ commands, each of them in their own \verb+\pstart…
 Page breaks are manually added before chapter with \verb+\beforeeledchapter+.
 }
 \beginnumbering
+
 \beforeeledchapter
 \pstart
 \eledchapter{\edtext{chapter}{\Afootnote{chapitre}}\ledsidenote{chapter}}

--- a/examples/2-titles_not_in_line_numbering.tex
+++ b/examples/2-titles_not_in_line_numbering.tex
@@ -1,8 +1,9 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 \usepackage[series={},nocritical,noend,noeledsec,nofamiliar,noledgroup]{reledmac}
 \begin{document}

--- a/examples/2-titles_not_in_line_numbering.tex
+++ b/examples/2-titles_not_in_line_numbering.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/3-reledpar_columns_different_languages.tex
+++ b/examples/3-reledpar_columns_different_languages.tex
@@ -1,4 +1,4 @@
-\documentclass{scrbook}
+\documentclass{book}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}
@@ -22,9 +22,8 @@
 \title{Parallel columns in two different languages}
 \date{}
 
+\maketitle
 
-
-{\let\newpage\relax\maketitle}
 {\small
 This file provides an example of typesetting parallel columns in two different languages, using reledpar, polyglossia and \XeLaTeX.
 

--- a/examples/3-reledpar_columns_different_languages.tex
+++ b/examples/3-reledpar_columns_different_languages.tex
@@ -1,24 +1,26 @@
-\documentclass{book}
-\usepackage[a4paper]{geometry}
-\usepackage{hyperref}
-\usepackage{polyglossia}
-\newcommand{\LuaLaTeX}{Lua\LaTeX}
+\documentclass{scrbook}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
 \usepackage[series={},nocritical,noend,nofamiliar,noledgroup]{reledmac}
-\usepackage{reledpar} 
+\usepackage{reledpar}
+
+\usepackage{graphicx}
+\usepackage{polyglossia}
+\setmainlanguage{english}
+\setotherlanguage{russian}
+\setotherlanguage{hebrew}
+\usepackage{metalogo}
 
 \linenumincrement*{1}
 \firstlinenum*{1}
 \setlength{\Lcolwidth}{0.48\textwidth}
 \setlength{\Rcolwidth}{0.48\textwidth} 
-\usepackage{libertine}
-\setmainlanguage{english}
-\setotherlanguage{russian}
-\setotherlanguage{hebrew}    
 
 \begin{document}
 
-\date{}
 \title{Parallel columns in two different languages}
+\date{}
 
 
 

--- a/examples/3-reledpar_mwe.tex
+++ b/examples/3-reledpar_mwe.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/3-reledpar_mwe.tex
+++ b/examples/3-reledpar_mwe.tex
@@ -1,8 +1,8 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{english}
-
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english]{babel}
 
 \usepackage[series={},nocritical,noend,noeledsec,nofamiliar,noledgroup]{reledmac}
 \usepackage{reledpar}

--- a/examples/3-reledpar_pages_different_languages_lualatex.tex
+++ b/examples/3-reledpar_pages_different_languages_lualatex.tex
@@ -1,22 +1,33 @@
-\documentclass{article}
-\usepackage{fontspec}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+
 \usepackage[series={},nocritical,noend,nofamiliar,noledgroup]{reledmac}
-\usepackage{reledpar,metalogo,hyperref}
-\setlength{\parindent}{0pt}
+\usepackage{reledpar}
 
-\newfontfamily\syriacfont[Script=Syriac,Scale=1.2]{estre.ttf}
+\usepackage{ifluatex}
+\ifluatex
+  \newcommand{\textsyriac}[1] % Syriac inside LTR
+             {\bgroup\textdir TRT\syriacfont #1\egroup}
+  \newenvironment{syriac}     % Syriac paragraph
+             {\textdir TRT\pardir TRT\syriacfont}{}
+\else
+  \usepackage{graphicx}
+  \usepackage{polyglossia}
+  \setmainlanguage{english}
+  \setotherlanguage{syriac}
+\fi
+\usepackage{metalogo}
 
-\newcommand{\textsyriac}[1] % Syriac inside LTR
-           {\bgroup\textdir TRT\syriacfont #1\egroup}
+\newfontfamily\syriacfont[Script=Syriac,Scale=1.2]{Estrangelo Edessa}
+
 \newcommand{\n}         [1] % for digits inside Arabic text
-           {\bgroup\textdir TLT #1\egroup}
+           {\bgroup\LTR  #1\egroup}
 \newcommand{\syriacfootnote} [1] % Syriac Footnotes
            {\footnote{\textsyriac{#1}}}
-\newenvironment{syriac}     % Syriac paragraph
-           {\textdir TRT\pardir TRT\syriacfont}{}
 
 \begin{document}
-
 \date{}
 \title{Using \LuaLaTeX\ to typeset RTL text with reledpar}
 \maketitle
@@ -28,16 +39,19 @@ It must be also called inside \verb+\eledsection+.
 
 For an example with \XeLaTeX, look at \href{./parallel-column-two-languages.tex}{parallel-column-two-languages.tex} file.
 \end{abstract}
+
 \begin{pages}
 \begin{Leftside}
 \begin{syriac}
 \beginnumbering
-   \pstart 
-       \eledsection*{\textsyriac{ܡܿܟܪܟܝ}}
+   \pstart
+       \eledsection*{\syriacfont{ܘܟܕ}}
    \pend
 
    \pstart
+
         1ܘܟܕ 2ܡܿܟܪܟܝ3ܢܢ ܐܪܟ4ܐܢܐ ܗ̄ 5ܡܘܪܐ6 ܗܿܝ ܩ7ܕܡܝܬܐ
+
    \pend
 \endnumbering
 \end{syriac}
@@ -54,7 +68,6 @@ For an example with \XeLaTeX, look at \href{./parallel-column-two-languages.tex}
    \pend
 \endnumbering
 \end{Rightside}
-
 
 \end{pages} 
 \Pages

--- a/examples/3-reledpar_pages_different_languages_lualatex.tex
+++ b/examples/3-reledpar_pages_different_languages_lualatex.tex
@@ -45,14 +45,12 @@ For an example with \XeLaTeX, look at \href{./parallel-column-two-languages.tex}
 \begin{Leftside}
 \begin{syriac}
 \beginnumbering
-   \pstart
-       \eledsection*{\textsyriac{ܘܟܕ}}
-   \pend
+   \pstart 
+	     \eledsection*{\textsyriac{ܡܿܟܪܟܝ}}
+	 \pend
 
    \pstart
-
         1ܘܟܕ 2ܡܿܟܪܟܝ3ܢܢ ܐܪܟ4ܐܢܐ ܗ̄ 5ܡܘܪܐ6 ܗܿܝ ܩ7ܕܡܝܬܐ
-
    \pend
 \endnumbering
 \end{syriac}

--- a/examples/3-reledpar_pages_different_languages_lualatex.tex
+++ b/examples/3-reledpar_pages_different_languages_lualatex.tex
@@ -45,9 +45,9 @@ For an example with \XeLaTeX, look at \href{./parallel-column-two-languages.tex}
 \begin{Leftside}
 \begin{syriac}
 \beginnumbering
-   \pstart 
-	     \eledsection*{\textsyriac{ܡܿܟܪܟܝ}}
-	 \pend
+   \pstart
+       \eledsection*{\textsyriac{ܡܿܟܪܟܝ}}
+   \pend
 
    \pstart
         1ܘܟܕ 2ܡܿܟܪܟܝ3ܢܢ ܐܪܟ4ܐܢܐ ܗ̄ 5ܡܘܪܐ6 ܗܿܝ ܩ7ܕܡܝܬܐ

--- a/examples/3-reledpar_pages_different_languages_lualatex.tex
+++ b/examples/3-reledpar_pages_different_languages_lualatex.tex
@@ -1,10 +1,12 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}
 
 \usepackage[series={},nocritical,noend,nofamiliar,noledgroup]{reledmac}
 \usepackage{reledpar}
+
+\newfontfamily\syriacfont{Estrangelo Edessa}[Script=Syriac,Scale=1.2]
 
 \usepackage{ifluatex}
 \ifluatex
@@ -17,14 +19,13 @@
   \usepackage{polyglossia}
   \setmainlanguage{english}
   \setotherlanguage{syriac}
+  \renewcommand{\textsyriac}[1]{\bgroup\syriacfont #1\egroup}
 \fi
 \usepackage{metalogo}
 
-\newfontfamily\syriacfont[Script=Syriac,Scale=1.2]{Estrangelo Edessa}
-
-\newcommand{\n}         [1] % for digits inside Arabic text
+\newcommand{\n}[1] % for digits inside Arabic text
            {\bgroup\LTR  #1\egroup}
-\newcommand{\syriacfootnote} [1] % Syriac Footnotes
+\newcommand{\syriacfootnote}[1] % Syriac Footnotes
            {\footnote{\textsyriac{#1}}}
 
 \begin{document}
@@ -32,7 +33,7 @@
 \title{Using \LuaLaTeX\ to typeset RTL text with reledpar}
 \maketitle
 \begin{abstract}
-This file provides an example on how to use  reledpar and \LuaLaTeX\ to typeset a right to left text with its translation on the facing page\footnote{The text was provided by Latechneuse on \url{http://tex.stackexchange.com/q/227837/7712}.}.  
+This file provides an example on how to use  reledpar and \LuaLaTeX\ to typeset a right to left text with its translation on the facing page\footnote{The text was provided by Latechneuse on \url{https://tex.stackexchange.com/q/227837/}.}.  
 
 As you can see, the switch to RTL convention is made \emph{before} the \verb+pstart+.
 It must be also called inside \verb+\eledsection+.
@@ -45,7 +46,7 @@ For an example with \XeLaTeX, look at \href{./parallel-column-two-languages.tex}
 \begin{syriac}
 \beginnumbering
    \pstart
-       \eledsection*{\syriacfont{ܘܟܕ}}
+       \eledsection*{\textsyriac{ܘܟܕ}}
    \pend
 
    \pstart

--- a/examples/3-reledpar_same_page_number_in_both_side.tex
+++ b/examples/3-reledpar_same_page_number_in_both_side.tex
@@ -1,9 +1,11 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english]{babel}
+
 \usepackage[series={},nocritical,noend,noeledsec,nofamiliar]{reledmac}
 \usepackage[sameparallelpagenumber]{reledpar}
-\setmainlanguage{english}
 
 \begin{document}
 \date{}

--- a/examples/3-reledpar_same_page_number_in_both_side.tex
+++ b/examples/3-reledpar_same_page_number_in_both_side.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass[a5paper,11pt]{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/3-reledpar_sync_setting_advancedshifted-nomax.tex
+++ b/examples/3-reledpar_sync_setting_advancedshifted-nomax.tex
@@ -1,4 +1,4 @@
-\documentclass[a5paper,12pt]{scrartcl}
+\documentclass[a5paper,11pt]{article}
 \usepackage{lmodern}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/3-reledpar_sync_setting_advancedshifted-nomax.tex
+++ b/examples/3-reledpar_sync_setting_advancedshifted-nomax.tex
@@ -1,14 +1,16 @@
-\documentclass[a5paper,12pt]{article}
-\usepackage{geometry}
-\usepackage[greek,english]{babel}
+\documentclass[a5paper,12pt]{scrartcl}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[polutonikogreek,main=english]{babel}
 \usepackage[pangram]{blindtext}
+
 \usepackage[series={A},noend,nocritical,noeledsec]{reledmac}
 \usepackage[advancedshiftedpstarts,nomaxlines]{reledpar}
 \maxhnotesX{0.2\textheight}
 \beforenotesX{5pt}
 \setgoalfraction{0.95}
 \begin{document}
-\large
 
 \date{}
 \title{Parallel setting}
@@ -26,8 +28,7 @@ This file provides an example of the way reledpar is synchronizing parallel page
             \pstart
                 1. \blindtext[21]
             \pend\pstart
-                2. \blindtext[10]
-                \footnoteAnomk{\selectlanguage{english}\blindtext[13]}
+                2. \blindtext[10]\footnoteAnomk{\selectlanguage{english}\blindtext[13]}
             \pend\pstart
                 3. \blindtext[6]
             \pend\pstart

--- a/examples/3-reledpar_sync_setting_advancedshifted-nomax.tex
+++ b/examples/3-reledpar_sync_setting_advancedshifted-nomax.tex
@@ -28,7 +28,8 @@ This file provides an example of the way reledpar is synchronizing parallel page
             \pstart
                 1. \blindtext[21]
             \pend\pstart
-                2. \blindtext[10]\footnoteAnomk{\selectlanguage{english}\blindtext[13]}
+                2. \blindtext[10]
+                \footnoteAnomk{\selectlanguage{english}\blindtext[13]}
             \pend\pstart
                 3. \blindtext[6]
             \pend\pstart

--- a/examples/3-reledpar_sync_setting_advancedshifted.tex
+++ b/examples/3-reledpar_sync_setting_advancedshifted.tex
@@ -1,4 +1,4 @@
-\documentclass[a5paper,12pt]{scrartcl}
+\documentclass[a5paper,11pt]{article}
 \usepackage{lmodern}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}
@@ -11,7 +11,6 @@
 \beforenotesX{5pt}
 \setgoalfraction{0.95}
 \begin{document}
-\large
 
 \date{}
 \title{Parallel setting}

--- a/examples/3-reledpar_sync_setting_advancedshifted.tex
+++ b/examples/3-reledpar_sync_setting_advancedshifted.tex
@@ -1,7 +1,10 @@
-\documentclass[a5paper,12pt]{article}
-\usepackage{geometry}
-\usepackage[greek,english]{babel}
+\documentclass[a5paper,12pt]{scrartcl}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[polutonikogreek,main=english]{babel}
 \usepackage[pangram]{blindtext}
+
 \usepackage[series={A},noend,nocritical,noeledsec]{reledmac}
 \usepackage[advancedshiftedpstarts]{reledpar}
 \maxhnotesX{0.2\textheight}

--- a/examples/3-reledpar_sync_setting_default.tex
+++ b/examples/3-reledpar_sync_setting_default.tex
@@ -1,7 +1,10 @@
-\documentclass[a5paper,12pt]{article}
-\usepackage{geometry}
-\usepackage[greek,english]{babel}
+\documentclass[a5paper,12pt]{scrartcl}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[polutonikogreek,main=english]{babel}
 \usepackage[pangram]{blindtext}
+
 \usepackage[series={A},noend,nocritical,noeledsec]{reledmac}
 \usepackage[]{reledpar}
 \maxhnotesX{0.2\textheight}

--- a/examples/3-reledpar_sync_setting_default.tex
+++ b/examples/3-reledpar_sync_setting_default.tex
@@ -1,4 +1,4 @@
-\documentclass[a5paper,12pt]{scrartcl}
+\documentclass[a5paper,11pt]{article}
 \usepackage{lmodern}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}
@@ -6,12 +6,10 @@
 \usepackage[pangram]{blindtext}
 
 \usepackage[series={A},noend,nocritical,noeledsec]{reledmac}
-\usepackage[]{reledpar}
-\maxhnotesX{0.2\textheight}
+\usepackage{reledpar}
 \beforenotesX{5pt}
 \setgoalfraction{0.95}
 \begin{document}
-\large
 
 \date{}
 \title{Parallel setting}

--- a/examples/3-reledpar_sync_setting_nomax-shifted.tex
+++ b/examples/3-reledpar_sync_setting_nomax-shifted.tex
@@ -1,7 +1,10 @@
-\documentclass[a5paper,12pt]{article}
-\usepackage{geometry}
-\usepackage[greek,english]{babel}
+\documentclass[a5paper,12pt]{scrartcl}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[polutonikogreek,main=english]{babel}
 \usepackage[pangram]{blindtext}
+
 \usepackage[series={A},noend,nocritical,noeledsec]{reledmac}
 \usepackage[nomaxlines,shiftedpstarts]{reledpar}
 \maxhnotesX{0.2\textheight}

--- a/examples/3-reledpar_sync_setting_nomax-shifted.tex
+++ b/examples/3-reledpar_sync_setting_nomax-shifted.tex
@@ -1,4 +1,4 @@
-\documentclass[a5paper,12pt]{scrartcl}
+\documentclass[a5paper,11pt]{article}
 \usepackage{lmodern}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}
@@ -11,7 +11,6 @@
 \beforenotesX{5pt}
 \setgoalfraction{0.95}
 \begin{document}
-\large
 
 \date{}
 \title{Parallel setting}

--- a/examples/3-reledpar_sync_setting_nomax.tex
+++ b/examples/3-reledpar_sync_setting_nomax.tex
@@ -1,7 +1,10 @@
-\documentclass[a5paper,12pt]{article}
-\usepackage{geometry}
-\usepackage[greek,english]{babel}
+\documentclass[a5paper,12pt]{scrartcl}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[polutonikogreek,main=english]{babel}
 \usepackage[pangram]{blindtext}
+
 \usepackage[series={A},noend,nocritical,noeledsec]{reledmac}
 \usepackage[nomaxlines]{reledpar}
 \maxhnotesX{0.2\textheight}

--- a/examples/3-reledpar_sync_setting_nomax.tex
+++ b/examples/3-reledpar_sync_setting_nomax.tex
@@ -1,4 +1,4 @@
-\documentclass[a5paper,12pt]{scrartcl}
+\documentclass[a5paper,11pt]{article}
 \usepackage{lmodern}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}
@@ -11,7 +11,6 @@
 \beforenotesX{5pt}
 \setgoalfraction{0.95}
 \begin{document}
-\large
 
 \date{}
 \title{Parallel setting}

--- a/examples/3-reledpar_sync_setting_nosync.tex
+++ b/examples/3-reledpar_sync_setting_nosync.tex
@@ -1,4 +1,4 @@
-\documentclass[a5paper,12pt]{scrartcl}
+\documentclass[a5paper,11pt]{article}
 \usepackage{lmodern}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}
@@ -11,7 +11,6 @@
 \beforenotesX{5pt}
 \setgoalfraction{0.95}
 \begin{document}
-\large
 
 \date{}
 \title{Parallel setting}

--- a/examples/3-reledpar_sync_setting_nosync.tex
+++ b/examples/3-reledpar_sync_setting_nosync.tex
@@ -1,7 +1,10 @@
-\documentclass[a5paper,12pt]{article}
-\usepackage{geometry}
-\usepackage[greek,english]{babel}
+\documentclass[a5paper,12pt]{scrartcl}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[polutonikogreek,main=english]{babel}
 \usepackage[pangram]{blindtext}
+
 \usepackage[series={A},noend,nocritical,noeledsec]{reledmac}
 \usepackage[nosyncpstarts]{reledpar}
 \maxhnotesX{0.2\textheight}

--- a/examples/3-reledpar_sync_setting_shifted.tex
+++ b/examples/3-reledpar_sync_setting_shifted.tex
@@ -1,7 +1,10 @@
-\documentclass[a5paper,12pt]{article}
-\usepackage{geometry}
-\usepackage[greek,english]{babel}
+\documentclass[a5paper,12pt]{scrartcl}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[polutonikogreek,main=english]{babel}
 \usepackage[pangram]{blindtext}
+
 \usepackage[series={A},noend,nocritical,noeledsec]{reledmac}
 \usepackage[shiftedpstarts]{reledpar}
 \maxhnotesX{0.2\textheight}

--- a/examples/3-reledpar_sync_setting_shifted.tex
+++ b/examples/3-reledpar_sync_setting_shifted.tex
@@ -1,4 +1,4 @@
-\documentclass[a5paper,12pt]{scrartcl}
+\documentclass[a5paper,11pt]{article}
 \usepackage{lmodern}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}
@@ -11,7 +11,6 @@
 \beforenotesX{5pt}
 \setgoalfraction{0.95}
 \begin{document}
-\large
 
 \date{}
 \title{Parallel setting}

--- a/examples/4-reledpar_column_mix_with_not_column-continuous-numbering.tex
+++ b/examples/4-reledpar_column_mix_with_not_column-continuous-numbering.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/4-reledpar_column_mix_with_not_column-continuous-numbering.tex
+++ b/examples/4-reledpar_column_mix_with_not_column-continuous-numbering.tex
@@ -1,9 +1,11 @@
-\documentclass{article}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
+
 \usepackage[noend,nofamiliar,series={A},noeledsec]{reledmac}
-\usepackage{polyglossia}
-\setmainlanguage{latin}
-\setotherlanguage{english}
-\usepackage{libertineotf}
 \usepackage[widthliketwocolumns,continuousnumberingwithcolumns]{reledpar}
 \setlength{\Lcolwidth}{0.47\textwidth}
 \setlength{\Rcolwidth}{0.47\textwidth}

--- a/examples/4-reledpar_column_mix_with_not_column.tex
+++ b/examples/4-reledpar_column_mix_with_not_column.tex
@@ -1,5 +1,7 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
 \usepackage[english, main=latin]{babel}
 \babeltags{english = english}
 

--- a/examples/4-reledpar_column_mix_with_not_column.tex
+++ b/examples/4-reledpar_column_mix_with_not_column.tex
@@ -1,13 +1,10 @@
-\documentclass[a4paper]{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
-
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 \usepackage[series={A,B},noend,noeledsec,noledgroup]{reledmac}
 \usepackage[widthliketwocolumns]{reledpar}
-
 
 \Xnoteswidthliketwocolumns
 \noteswidthliketwocolumnsX

--- a/examples/4-reledpar_columns_alignment.tex
+++ b/examples/4-reledpar_columns_alignment.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/4-reledpar_columns_alignment.tex
+++ b/examples/4-reledpar_columns_alignment.tex
@@ -1,8 +1,9 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english]{babel}
 \usepackage[showframe]{geometry}
-\usepackage{libertineotf}
-\setmainlanguage{english}
 
 \usepackage[series={},nocritical,noend,noeledsec,nofamiliar,noledgroup]{reledmac}
 \usepackage{reledpar}
@@ -19,11 +20,11 @@
 \date{}
 \maketitle
 \begin{abstract}
-This file provides example of setting the alignment of \verb+\Columns+ on the page: right (default), left or center.
+This file provides example of setting the alignment of \texttt{\textbackslash{}Columns} on the page: right (default), left or center.
 
-The column are 0.44\verb+\textwidth+, and we use \verb+\columnsposition+.
+The column are 0.44\texttt{\textbackslash{}textwidth}, and we use \texttt{\textbackslash{}columnsposition}.
 
-We also provide a last example, showing how we can manipulate space between colons, by redefining \verb+\beforecolumnseparator+ and \verb+\aftercolumnseparator+.
+We also provide a last example, showing how we can manipulate space between colons, by redefining \texttt{\textbackslash{}beforecolumnseparator} and \texttt{\textbackslash{}aftercolumnseparator}.
 \end{abstract}
 
 

--- a/examples/4-reledpar_columns_titles_in_line_numbering_with_notes.tex
+++ b/examples/4-reledpar_columns_titles_in_line_numbering_with_notes.tex
@@ -1,4 +1,4 @@
-\documentclass{scrbook}
+\documentclass{book}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/4-reledpar_columns_titles_in_line_numbering_with_notes.tex
+++ b/examples/4-reledpar_columns_titles_in_line_numbering_with_notes.tex
@@ -1,7 +1,8 @@
-\documentclass[oneside,12pt]{book}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{english}
+\documentclass{scrbook}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english]{babel}
 
 \usepackage[series={A},noend,nofamiliar,noledgroup]{reledmac}
 \usepackage{reledpar}

--- a/examples/4-reledpar_inside-outside-columns.tex
+++ b/examples/4-reledpar_inside-outside-columns.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/4-reledpar_inside-outside-columns.tex
+++ b/examples/4-reledpar_inside-outside-columns.tex
@@ -1,8 +1,8 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{english}
-
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english]{babel}
 
 \usepackage[series={},nocritical,noend,noeledsec,nofamiliar,noledgroup]{reledmac}
 \usepackage[movecolumnspositiononrightpage]{reledpar}
@@ -10,16 +10,13 @@
 \setlength{\Lcolwidth}{0.65\textwidth}
 \setlength{\Rcolwidth}{0.25\textwidth}
 
-
 \begin{document}
-\begin{english}
 \title{Working with outside and inside columns}
 \date{}
 \maketitle
 \begin{abstract}
 This file shows an example of the \verb+movecolumnspositiononrightpage+ option in action. This option allows to have inside and outside columns, rather than left and right columns.
 \end{abstract}
-\end{english}
 \AtBeginPairs{\sloppy}
 \begin{pairs}
     \begin{Leftside}

--- a/examples/4-reledpar_one_series_per_pstart.tex
+++ b/examples/4-reledpar_one_series_per_pstart.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/4-reledpar_one_series_per_pstart.tex
+++ b/examples/4-reledpar_one_series_per_pstart.tex
@@ -1,11 +1,13 @@
-\documentclass{article}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english]{babel}
 \usepackage{lipsum}
 \SetLipsumParListEnd{\par}
+
 \usepackage[series={A,B,C,D,E,F,G,H,I,J},noend,nofamiliar,noledgroup,noeledsec]{reledmac}%Declare series to be used
 \usepackage{reledpar}
-\usepackage{polyglossia}
-\setmainlanguage{english}
-\usepackage{libertine}
 
 % Here is the loop system:
 \makeatletter% We need to use command with @

--- a/examples/4-reledpar_pages_long_notes.tex
+++ b/examples/4-reledpar_pages_long_notes.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/4-reledpar_pages_long_notes.tex
+++ b/examples/4-reledpar_pages_long_notes.tex
@@ -1,16 +1,15 @@
-\documentclass{article}
-\usepackage{fontspec}
-\usepackage{libertineotf}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english,french,main=latin]{babel}
+\babeltags{english = english}
+\babeltags{french = french}
 
 \usepackage[series={A,B,C},noend,noeledsec,noledgroup]{reledmac}
 \usepackage{reledpar}
 \setgoalfraction{0.98}
 \Xmaxhnotes{0.25\textheight}
-
-\usepackage{polyglossia}
-\setmainlanguage{latin}
-\setotherlanguage{french}
-\setotherlanguage{english}
 
 %http://remacle.org/bloodwolf/historiens/dictys/troie.htm
 \newcounter{Atest}

--- a/examples/4-reledpar_pages_notes_leftpage.tex
+++ b/examples/4-reledpar_pages_notes_leftpage.tex
@@ -1,5 +1,7 @@
-\documentclass[twoside]{scrartcl}
+\documentclass[twoside]{article}
 \usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
 \usepackage[english, main=latin]{babel}
 \babeltags{english = english}
 \usepackage{blindtext}

--- a/examples/4-reledpar_pages_notes_leftpage.tex
+++ b/examples/4-reledpar_pages_notes_leftpage.tex
@@ -29,13 +29,15 @@ The notes of series \verb+A+ are called on the left side with \verb+footnoteAnom
     \beginnumbering
     \autopar
 
-    \blindtext\footnoteAnomk{\blindtext} \blindtext 
+   Lorem\footnoteAnomk{A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side.} ipsum dolor sit amet, consectetur adipiscing elit. Vivamus id erat imperdiet, sollicitudin tortor a, rhoncus ipsum. Aliquam at maximus nibh. Ut sed risus porttitor, eleifend tortor non, commodo nisl. Praesent eu ullamcorper est. Phasellus at eros eget ex feugiat scelerisque. 
     
-  	\blindtext
+	Vivamus et luctus justo. In aliquet, metus malesuada vestibulum ullamcorper, est sapien facilisis arcu, ac efficitur mi metus ac velit. Sed sagittis laoreet justo at iaculis. 
 
-  	\blindtext\footnoteAnomk{\blindtext} \blindtext 
+	Aliquam\footnoteAnomk{An other note called in right side, but printed in left side.  An other note called in right side, but printed in left side. An other note called in right side, but printed in left side. An other note called in right side, but printed in left side. An other note called in right side, but printed in left side. An other note called in right side, but printed in left side. An other note called in right side, but printed in left side.} eu erat id tellus bibendum semper eu eget nulla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nunc arcu, iaculis sit amet laoreet ut, finibus at nibh. 
 
-  	\blindtext[2]
+	Curabitur non lacus eget tellus consectetur dignissim. Nullam a tempus enim. Donec ut pulvinar magna, in accumsan velit. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec lacinia scelerisque urna, sagittis fermentum est ultricies semper. 
+
+	Aenean condimentum, leo vitae convallis porta, neque felis rhoncus metus, in iaculis nulla ligula vitae quam. Fusce at vehicula purus, id sollicitudin dolor. Maecenas scelerisque non est non luctus. Aliquam erat volutpat. Praesent eu placerat urna. Donec fermentum mauris sit amet nulla semper lacinia. Donec eu ipsum ultricies, placerat odio id, ultrices urna. Cras id sapien ut nisi auctor elementum vel id tellus.
 
     \endnumbering
   \end{Leftside}
@@ -43,17 +45,18 @@ The notes of series \verb+A+ are called on the left side with \verb+footnoteAnom
   \begin{Rightside}
     \beginnumbering
     \autopar
-    \blindtext\footnoteAmk \blindtext
+    Lorem\footnoteAmk ipsum dolor sit amet, consectetur adipiscing elit. Vivamus id erat imperdiet, sollicitudin tortor a, rhoncus ipsum. Aliquam at maximus nibh. Ut sed risus porttitor, eleifend tortor non, commodo nisl. Praesent eu ullamcorper est. Phasellus at eros eget ex feugiat scelerisque. Proin pellentesque lorem eu risus convallis consectetur ac molestie turpis. Maecenas blandit iaculis orci, et mattis dolor luctus vel. Praesent placerat varius tellus, nec convallis purus volutpat at. Vivamus sit amet est interdum, condimentum sem ultricies, posuere sapien. Maecenas vitae sapien diam. Donec et risus non nunc laoreet tincidunt. Pellentesque vehicula pellentesque sagittis. Morbi elementum tempus nunc, eu sodales erat convallis et. Maecenas condimentum pretium faucibus. Nam in ante nunc. Etiam lobortis, arcu a imperdiet interdum, felis erat mattis nunc, id posuere purus nisl a nibh.
     
-	  \blindtext
+	Vivamus et luctus justo. In aliquet, metus malesuada vestibulum ullamcorper, est sapien facilisis arcu, ac efficitur mi metus ac velit. Sed sagittis laoreet justo at iaculis. Morbi scelerisque nec quam eu efficitur. Integer nec massa ut lectus viverra ornare sed id libero. Praesent fermentum suscipit ante ut aliquam. Sed facilisis rutrum sapien vel blandit. Ut eget ex ut massa consequat sodales. Vestibulum venenatis in quam a molestie.
 
-	  \blindtext\footnoteAmk \blindtext
+	Aliquam\footnoteAmk eu erat id tellus bibendum semper eu eget nulla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nunc arcu, iaculis sit amet laoreet ut, finibus at nibh. Aliquam vel nisl a sem pulvinar efficitur. Quisque dignissim, metus at consectetur ultrices, metus nunc ultrices quam, at ultrices dolor massa vitae urna. Nullam semper nisi dui, vel commodo mi lobortis sit amet. In non mattis orci. Integer aliquam dapibus convallis. Suspendisse sodales tincidunt ante quis laoreet. Etiam sodales mauris nulla, vitae mattis est consequat sit amet. Nam blandit rhoncus nisi. Sed accumsan, nibh non venenatis aliquam, dolor quam sodales turpis, nec aliquam nunc arcu quis urna.
 
-	  \blindtext[2]
+	Curabitur non lacus eget tellus consectetur dignissim. Nullam a tempus enim. Donec ut pulvinar magna, in accumsan velit. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec lacinia scelerisque urna, sagittis fermentum est ultricies semper. Phasellus non augue ligula. Donec aliquet bibendum elit, quis tempor risus pulvinar id. Curabitur a cursus enim. Integer sit amet accumsan urna. Nam viverra at tortor ac gravida. In hac habitasse platea dictumst. Morbi imperdiet eleifend risus id consequat. Proin blandit mi a elit vehicula, a semper quam lacinia. Pellentesque at iaculis diam, quis condimentum justo. Nulla laoreet ut mauris sed tempor.
+
+	Aenean condimentum, leo vitae convallis porta, neque felis rhoncus metus, in iaculis nulla ligula vitae quam. Fusce at vehicula purus, id sollicitudin dolor. Maecenas scelerisque non est non luctus. Aliquam erat volutpat. Praesent eu placerat urna. Donec fermentum mauris sit amet nulla semper lacinia. 
     
     \endnumbering
   \end{Rightside}
-
 
 \end{pages}
   \Pages

--- a/examples/4-reledpar_pages_notes_leftpage.tex
+++ b/examples/4-reledpar_pages_notes_leftpage.tex
@@ -4,7 +4,6 @@
 \usepackage[pdfusetitle,hidelinks]{hyperref}
 \usepackage[english, main=latin]{babel}
 \babeltags{english = english}
-\usepackage{blindtext}
 
 \usepackage[series={A},nocritical,noend,noeledsec,noledgroup]{reledmac}
 \usepackage[shiftedpstarts]{reledpar}

--- a/examples/4-reledpar_pages_notes_leftpage.tex
+++ b/examples/4-reledpar_pages_notes_leftpage.tex
@@ -1,18 +1,11 @@
-\documentclass[a4paper]{article}
-
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
-\usepackage{csquotes}
-
+\documentclass[twoside]{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
+\usepackage{blindtext}
 
 \usepackage[series={A},nocritical,noend,noeledsec,noledgroup]{reledmac}
 \usepackage[shiftedpstarts]{reledpar}
-\usepackage{setspace}
-
-\onehalfspacing
-
 
 \begin{document}
 
@@ -34,15 +27,13 @@ The notes of series \verb+A+ are called on the left side with \verb+footnoteAnom
     \beginnumbering
     \autopar
 
-   Lorem\footnoteAnomk{A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side. A note called in right side, but printed in left side.} ipsum dolor sit amet, consectetur adipiscing elit. Vivamus id erat imperdiet, sollicitudin tortor a, rhoncus ipsum. Aliquam at maximus nibh. Ut sed risus porttitor, eleifend tortor non, commodo nisl. Praesent eu ullamcorper est. Phasellus at eros eget ex feugiat scelerisque. 
+    \blindtext\footnoteAnomk{\blindtext} \blindtext 
     
-	Vivamus et luctus justo. In aliquet, metus malesuada vestibulum ullamcorper, est sapien facilisis arcu, ac efficitur mi metus ac velit. Sed sagittis laoreet justo at iaculis. 
+  	\blindtext
 
-	Aliquam\footnoteAnomk{An other note called in right side, but printed in left side.  An other note called in right side, but printed in left side. An other note called in right side, but printed in left side. An other note called in right side, but printed in left side. An other note called in right side, but printed in left side. An other note called in right side, but printed in left side. An other note called in right side, but printed in left side.} eu erat id tellus bibendum semper eu eget nulla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nunc arcu, iaculis sit amet laoreet ut, finibus at nibh. 
+  	\blindtext\footnoteAnomk{\blindtext} \blindtext 
 
-	Curabitur non lacus eget tellus consectetur dignissim. Nullam a tempus enim. Donec ut pulvinar magna, in accumsan velit. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec lacinia scelerisque urna, sagittis fermentum est ultricies semper. 
-
-	Aenean condimentum, leo vitae convallis porta, neque felis rhoncus metus, in iaculis nulla ligula vitae quam. Fusce at vehicula purus, id sollicitudin dolor. Maecenas scelerisque non est non luctus. Aliquam erat volutpat. Praesent eu placerat urna. Donec fermentum mauris sit amet nulla semper lacinia. Donec eu ipsum ultricies, placerat odio id, ultrices urna. Cras id sapien ut nisi auctor elementum vel id tellus.
+  	\blindtext[2]
 
     \endnumbering
   \end{Leftside}
@@ -50,15 +41,13 @@ The notes of series \verb+A+ are called on the left side with \verb+footnoteAnom
   \begin{Rightside}
     \beginnumbering
     \autopar
-    Lorem\footnoteAmk ipsum dolor sit amet, consectetur adipiscing elit. Vivamus id erat imperdiet, sollicitudin tortor a, rhoncus ipsum. Aliquam at maximus nibh. Ut sed risus porttitor, eleifend tortor non, commodo nisl. Praesent eu ullamcorper est. Phasellus at eros eget ex feugiat scelerisque. Proin pellentesque lorem eu risus convallis consectetur ac molestie turpis. Maecenas blandit iaculis orci, et mattis dolor luctus vel. Praesent placerat varius tellus, nec convallis purus volutpat at. Vivamus sit amet est interdum, condimentum sem ultricies, posuere sapien. Maecenas vitae sapien diam. Donec et risus non nunc laoreet tincidunt. Pellentesque vehicula pellentesque sagittis. Morbi elementum tempus nunc, eu sodales erat convallis et. Maecenas condimentum pretium faucibus. Nam in ante nunc. Etiam lobortis, arcu a imperdiet interdum, felis erat mattis nunc, id posuere purus nisl a nibh.
+    \blindtext\footnoteAmk \blindtext
     
-	Vivamus et luctus justo. In aliquet, metus malesuada vestibulum ullamcorper, est sapien facilisis arcu, ac efficitur mi metus ac velit. Sed sagittis laoreet justo at iaculis. Morbi scelerisque nec quam eu efficitur. Integer nec massa ut lectus viverra ornare sed id libero. Praesent fermentum suscipit ante ut aliquam. Sed facilisis rutrum sapien vel blandit. Ut eget ex ut massa consequat sodales. Vestibulum venenatis in quam a molestie.
+	  \blindtext
 
-	Aliquam\footnoteAmk eu erat id tellus bibendum semper eu eget nulla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nunc arcu, iaculis sit amet laoreet ut, finibus at nibh. Aliquam vel nisl a sem pulvinar efficitur. Quisque dignissim, metus at consectetur ultrices, metus nunc ultrices quam, at ultrices dolor massa vitae urna. Nullam semper nisi dui, vel commodo mi lobortis sit amet. In non mattis orci. Integer aliquam dapibus convallis. Suspendisse sodales tincidunt ante quis laoreet. Etiam sodales mauris nulla, vitae mattis est consequat sit amet. Nam blandit rhoncus nisi. Sed accumsan, nibh non venenatis aliquam, dolor quam sodales turpis, nec aliquam nunc arcu quis urna.
+	  \blindtext\footnoteAmk \blindtext
 
-	Curabitur non lacus eget tellus consectetur dignissim. Nullam a tempus enim. Donec ut pulvinar magna, in accumsan velit. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec lacinia scelerisque urna, sagittis fermentum est ultricies semper. Phasellus non augue ligula. Donec aliquet bibendum elit, quis tempor risus pulvinar id. Curabitur a cursus enim. Integer sit amet accumsan urna. Nam viverra at tortor ac gravida. In hac habitasse platea dictumst. Morbi imperdiet eleifend risus id consequat. Proin blandit mi a elit vehicula, a semper quam lacinia. Pellentesque at iaculis diam, quis condimentum justo. Nulla laoreet ut mauris sed tempor.
-
-	Aenean condimentum, leo vitae convallis porta, neque felis rhoncus metus, in iaculis nulla ligula vitae quam. Fusce at vehicula purus, id sollicitudin dolor. Maecenas scelerisque non est non luctus. Aliquam erat volutpat. Praesent eu placerat urna. Donec fermentum mauris sit amet nulla semper lacinia. 
+	  \blindtext[2]
     
     \endnumbering
   \end{Rightside}

--- a/examples/4-reledpar_pages_paragraph_separator_between.tex
+++ b/examples/4-reledpar_pages_paragraph_separator_between.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/4-reledpar_pages_paragraph_separator_between.tex
+++ b/examples/4-reledpar_pages_paragraph_separator_between.tex
@@ -1,8 +1,9 @@
-\documentclass{article}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 \usepackage[series={},nocritical,noend,noeledsec,nofamiliar,noledgroup]{reledmac}
 \usepackage{reledpar}

--- a/examples/4-reledpar_pages_titles_in_line_numbering_with_notes.tex
+++ b/examples/4-reledpar_pages_titles_in_line_numbering_with_notes.tex
@@ -1,7 +1,8 @@
-\documentclass[twoside,12pt]{book}
-\usepackage{polyglossia,fontspec}
-\usepackage{libertineotf}
-\setmainlanguage{english}
+\documentclass{scrbook}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english]{babel}
 
 \usepackage[series={A},noend,nofamiliar,noledgroup]{reledmac}
 \usepackage{reledpar}

--- a/examples/4-reledpar_pages_titles_in_line_numbering_with_notes.tex
+++ b/examples/4-reledpar_pages_titles_in_line_numbering_with_notes.tex
@@ -1,4 +1,4 @@
-\documentclass{scrbook}
+\documentclass{book}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/4-reledpar_titles_not_in_line_numbering.tex
+++ b/examples/4-reledpar_titles_not_in_line_numbering.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/4-reledpar_titles_not_in_line_numbering.tex
+++ b/examples/4-reledpar_titles_not_in_line_numbering.tex
@@ -1,9 +1,9 @@
-\documentclass{article}
-\usepackage{fontspec}
-\usepackage{libertineotf}
-\usepackage{polyglossia}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 \usepackage[series={},nocritical,noend,noeledsec,nofamiliar,noledgroup]{reledmac}
 \usepackage{reledpar}

--- a/examples/4-reledpar_verse_text_between.tex
+++ b/examples/4-reledpar_verse_text_between.tex
@@ -1,4 +1,4 @@
-\documentclass{scrartcl}
+\documentclass{article}
 \usepackage[osf,p]{libertinus}
 \usepackage{microtype}
 \usepackage[pdfusetitle,hidelinks]{hyperref}

--- a/examples/4-reledpar_verse_text_between.tex
+++ b/examples/4-reledpar_verse_text_between.tex
@@ -1,9 +1,9 @@
-\documentclass{article}
-\usepackage{fontspec}
-\usepackage{libertineotf}
-\usepackage{polyglossia}
-\setmainlanguage{latin}
-\setotherlanguage{english}
+\documentclass{scrartcl}
+\usepackage[osf,p]{libertinus}
+\usepackage{microtype}
+\usepackage[pdfusetitle,hidelinks]{hyperref}
+\usepackage[english, main=latin]{babel}
+\babeltags{english = english}
 
 \usepackage[series={},noeledsec,nocritical,nofamiliar,noend,noledgroup]{reledmac}
 \usepackage{reledpar}

--- a/examples/latexmkrc
+++ b/examples/latexmkrc
@@ -1,1 +1,2 @@
-$pdf_mode = "5";
+$pdf_mode = 5;
+$postscript_mode = $dvi_mode = 0;

--- a/examples/makefile
+++ b/examples/makefile
@@ -25,4 +25,4 @@ PDF:$(OBJ)
 	latexmk --lualatex $<
 
 clean:
-	@$(RM) *pdf *toc *.1* *.2* *.3* *.eledsec* *.log *.fdb_latexmk *.aux *.end *.ilg *.ind *.idx *.out *.synctex.gz *.synctex.gz\(busy\)
+	@$(RM) *pdf *toc *.1* *.2* *.3* *.4* *.5* *.6* *.7* *.8* *.9* *.eledsec* *.Aend* *.Bend* *.fls* *.xdv* *.glg* *.glo* *.gls* *.ist* *.log *.fdb_latexmk *.aux *.end *.ilg *.ind *.idx *.out *.synctex.gz *.synctex.gz\(busy\)


### PR DESCRIPTION
Ce PR fait autant d'exemples que possible compatibles avec PDFTeX, XeTeX et LuaTeX (avec Babel et Libertinus). Il normalise l'apparence à l'aide de KOMA-Script (pour A4 par défaut etc.).

En remerciement pour toute votre aide récente !