### PR TITLE
Update reledmac.dtx

### DIFF
--- a/reledmac.dtx
+++ b/reledmac.dtx
@@ -582,11 +582,13 @@
 %
 % \author{%
 % Ma\"ieul Rouquette\thanks{\texttt{maieul at maieul dot net}} \\
-% {\small based on the original \protect\package{ledmac} by} \\
+% {\small based on the \protect\package{ledmac} by} \\
 % Peter Wilson \\
 % Herries Press \\
-% {\small which was based on the original \edmac, \tabmac{} and \edstanza{} by} \\
-% John Lavagnino, Dominik Wujastyk, Herbert Breger and Wayne Sullivan.
+% {\small with the plugins \tabmac{} and \edstanza{} by}\\
+% Herbert Breger and Wayne Sullivan,
+% {\small all based on EDMAC by} \\
+% John Lavagnino and Dominik Wujastyk
 % }
 %
 % \date{}


### PR DESCRIPTION
Rephrased the contents of \author better to reflect the evolution from EDMAC (which was always in caps, like METAFONT).