### PR TITLE
Drop a stray period

### DIFF
--- a/reledpar.dtx
+++ b/reledpar.dtx
@@ -347,7 +347,7 @@
 % \changes{v2.24.1}{2020/08/19}{Fix incompatibility between lineation by \protect\cs{pstart} and (a)stanza.}
 % \changes{v2.24.2}{2020/09/16}{Fix some bugs with lineation by page, when a numbered section starts at the very beginning of page.}
 % \changes{v2.24.3}{2020/11/08}{Fix bug with hanging verse in parallel typesetting.}
-% \changes{v2.25.0}{2020/11/29}{Add compatibility with \protect\cs{linenumannotationothersidetrue} of \protect\macpackage.}.
+% \changes{v2.25.0}{2020/11/29}{Add compatibility with \protect\cs{linenumannotationothersidetrue} of \protect\macpackage.}
 % \changes{v2.25.1}{2021/01/21}{\protect\cs{ifsublines@R} migrated to \protect\macpackage}
 % \changes{v2.25.2}{2021/09/27}{Fix incompatibility with \protect\package{babel} v3.61}
 % \changes{v2.25.3}{2022/04/22}{Fix incompatibility with \protect\package{polyglossia} v1.55}


### PR DESCRIPTION
It caused an almost empty first doc page.